### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 quint
 -----
 
-.. image:: https://pypip.in/version/quint/badge.svg
+.. image:: https://img.shields.io/pypi/v/quint.svg
     :target: https://pypi.python.org/pypi/quint/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/quint/badge.svg
+.. image:: https://img.shields.io/pypi/l/quint.svg
     :target: https://pypi.python.org/pypi/quint/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20quint))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `quint`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.